### PR TITLE
added conda-install-option and badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!--- BADGES: START --->
 [![GitHub - License](https://img.shields.io/github/license/koaning/doubtlab?logo=github&style=flat&color=green)][#github-license]
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/doubtlab?logo=pypi&style=flat&color=blue)][#pypi-doubtlab]
 [![PyPI - Package Version](https://img.shields.io/pypi/v/doubtlab?logo=pypi&style=flat&color=orange)][#pypi-doubtlab]
@@ -7,10 +8,11 @@
 [![Docs - GitHub.io](https://img.shields.io/badge/docs-doubtlab-green?logo=github&style=flat&color=pink)][#docs-doubtlab]
 <!--- [![Conda](https://img.shields.io/conda/dn/conda-forge/doubtlab?logo=anaconda)][#conda-forge-doubtlab] --->
 
-[#github-license]: LICENSE
+[#github-license]: https://github.com/koaning/doubtlab/blob/main/LICENSE
 [#pypi-doubtlab]: https://pypi.org/project/doubtlab/
 [#conda-forge-doubtlab]: https://anaconda.org/conda-forge/doubtlab
 [#docs-doubtlab]: https://koaning.github.io/doubtlab/
+<!--- BADGES: END --->
 
 <img src="docs/doubt.png" width=125 height=125 align="right">
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 <!--- BADGES: START --->
 [![GitHub - License](https://img.shields.io/github/license/koaning/doubtlab?logo=github&style=flat&color=green)][#github-license]
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/doubtlab?logo=pypi&style=flat&color=blue)][#pypi-doubtlab]
-[![PyPI - Package Version](https://img.shields.io/pypi/v/doubtlab?logo=pypi&style=flat&color=orange)][#pypi-doubtlab]
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/doubtlab?logo=pypi&style=flat&color=green)][#pypi-doubtlab]
-[![Conda - Platform](https://img.shields.io/conda/pn/conda-forge/doubtlab?logo=anaconda&style=flat)][#conda-forge-doubtlab]
-[![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/doubtlab?logo=anaconda&style=flat&color=orange)][#conda-forge-doubtlab]
-[![Docs - GitHub.io](https://img.shields.io/badge/docs-doubtlab-green?logo=github&style=flat&color=pink)][#docs-doubtlab]
-<!--- [![Conda](https://img.shields.io/conda/dn/conda-forge/doubtlab?logo=anaconda)][#conda-forge-doubtlab] --->
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/doubtlab?logo=pypi&style=flat&color=blue)][#pypi-package]
+[![PyPI - Package Version](https://img.shields.io/pypi/v/doubtlab?logo=pypi&style=flat&color=orange)][#pypi-package]
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/doubtlab?logo=pypi&style=flat&color=green)][#pypi-package]
+[![Conda - Platform](https://img.shields.io/conda/pn/conda-forge/doubtlab?logo=anaconda&style=flat)][#conda-forge-package]
+[![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/doubtlab?logo=anaconda&style=flat&color=orange)][#conda-forge-package]
+[![Docs - GitHub.io](https://img.shields.io/static/v1?logo=github&style=flat&color=pink&label=docs&message=doubtlab)][#docs-package]
+<!--- [![Conda](https://img.shields.io/conda/dn/conda-forge/doubtlab?logo=anaconda)][#conda-forge-package] --->
 
 [#github-license]: https://github.com/koaning/doubtlab/blob/main/LICENSE
-[#pypi-doubtlab]: https://pypi.org/project/doubtlab/
-[#conda-forge-doubtlab]: https://anaconda.org/conda-forge/doubtlab
-[#docs-doubtlab]: https://koaning.github.io/doubtlab/
+[#pypi-package]: https://pypi.org/project/doubtlab/
+[#conda-forge-package]: https://anaconda.org/conda-forge/doubtlab
+[#docs-package]: https://koaning.github.io/doubtlab/
 <!--- BADGES: END --->
 
 <img src="docs/doubt.png" width=125 height=125 align="right">

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 [![GitHub - License](https://img.shields.io/github/license/koaning/doubtlab?logo=github&style=flat&color=green)][#github-license]
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/doubtlab?logo=pypi&style=flat&color=blue)][#pypi-package]
 [![PyPI - Package Version](https://img.shields.io/pypi/v/doubtlab?logo=pypi&style=flat&color=orange)][#pypi-package]
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/doubtlab?logo=pypi&style=flat&color=green)][#pypi-package]
 [![Conda - Platform](https://img.shields.io/conda/pn/conda-forge/doubtlab?logo=anaconda&style=flat)][#conda-forge-package]
 [![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/doubtlab?logo=anaconda&style=flat&color=orange)][#conda-forge-package]
 [![Docs - GitHub.io](https://img.shields.io/static/v1?logo=github&style=flat&color=pink&label=docs&message=doubtlab)][#docs-package]
-<!--- [![Conda](https://img.shields.io/conda/dn/conda-forge/doubtlab?logo=anaconda)][#conda-forge-package] --->
+<!--- 
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/doubtlab?logo=pypi&style=flat&color=green)][#pypi-package]
+[![Conda](https://img.shields.io/conda/dn/conda-forge/doubtlab?logo=anaconda)][#conda-forge-package] 
+--->
 
 [#github-license]: https://github.com/koaning/doubtlab/blob/main/LICENSE
 [#pypi-package]: https://pypi.org/project/doubtlab/

--- a/README.md
+++ b/README.md
@@ -5,10 +5,7 @@
 [![Conda - Platform](https://img.shields.io/conda/pn/conda-forge/doubtlab?logo=anaconda&style=flat)][#conda-forge-package]
 [![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/doubtlab?logo=anaconda&style=flat&color=orange)][#conda-forge-package]
 [![Docs - GitHub.io](https://img.shields.io/static/v1?logo=github&style=flat&color=pink&label=docs&message=doubtlab)][#docs-package]
-<!--- 
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/doubtlab?logo=pypi&style=flat&color=green)][#pypi-package]
-[![Conda](https://img.shields.io/conda/dn/conda-forge/doubtlab?logo=anaconda)][#conda-forge-package] 
---->
+
 
 [#github-license]: https://github.com/koaning/doubtlab/blob/main/LICENSE
 [#pypi-package]: https://pypi.org/project/doubtlab/

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 [![GitHub - License](https://img.shields.io/github/license/koaning/doubtlab?logo=github&style=flat&color=green)][#github-license]
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/doubtlab?logo=pypi&style=flat&color=blue)][#pypi-doubtlab]
 [![PyPI - Package Version](https://img.shields.io/pypi/v/doubtlab?logo=pypi&style=flat&color=orange)][#pypi-doubtlab]
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/doubtlab?logo=pypi)][#pypi-doubtlab]
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/doubtlab?logo=pypi&style=flat&color=green)][#pypi-doubtlab]
 [![Conda - Platform](https://img.shields.io/conda/pn/conda-forge/doubtlab?logo=anaconda&style=flat)][#conda-forge-doubtlab]
 [![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/doubtlab?logo=anaconda&style=flat&color=orange)][#conda-forge-doubtlab]
+[![Docs - GitHub.io](https://img.shields.io/badge/docs-doubtlab-green?logo=github&style=flat&color=pink)][#docs-doubtlab]
 <!--- [![Conda](https://img.shields.io/conda/dn/conda-forge/doubtlab?logo=anaconda)][#conda-forge-doubtlab] --->
 
 [#github-license]: LICENSE
 [#pypi-doubtlab]: https://pypi.org/project/doubtlab/
 [#conda-forge-doubtlab]: https://anaconda.org/conda-forge/doubtlab
+[#docs-doubtlab]: https://koaning.github.io/doubtlab/
 
 <img src="docs/doubt.png" width=125 height=125 align="right">
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+[![GitHub - License](https://img.shields.io/github/license/koaning/doubtlab?logo=github&style=flat&color=green)][#github-license]
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/doubtlab?logo=pypi&style=flat&color=blue)][#pypi-doubtlab]
+[![PyPI - Package Version](https://img.shields.io/pypi/v/doubtlab?logo=pypi&style=flat&color=orange)][#pypi-doubtlab]
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/doubtlab?logo=pypi)][#pypi-doubtlab]
+[![Conda - Platform](https://img.shields.io/conda/pn/conda-forge/doubtlab?logo=anaconda&style=flat)][#conda-forge-doubtlab]
+[![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/doubtlab?logo=anaconda&style=flat&color=orange)][#conda-forge-doubtlab]
+<!--- [![Conda](https://img.shields.io/conda/dn/conda-forge/doubtlab?logo=anaconda)][#conda-forge-doubtlab] --->
+
+[#github-license]: LICENSE
+[#pypi-doubtlab]: https://pypi.org/project/doubtlab/
+[#conda-forge-doubtlab]: https://anaconda.org/conda-forge/doubtlab
+
 <img src="docs/doubt.png" width=125 height=125 align="right">
 
 # doubtlab
@@ -8,10 +20,18 @@ This repository contains general tricks that may help you find bad, or noisy, la
 
 ## Install
 
-You can install the tool via pip.
+You can install the tool via `pip` or `conda`.
+
+**Install with pip**
 
 ```
 python -m pip install doubtlab
+```
+
+**Install with conda**
+
+```
+conda install -c conda-forge doubtlab
 ```
 
 ## Quickstart


### PR DESCRIPTION
This closes #14: `doubtlab` can now be installed with **conda** from `conda-forge` channel. 

- [x] Created [conda-forge/doubtlab-feedstock](https://github.com/conda-forge/doubtlab-feedstock) to make `doubtlab` available on conda-forge channel. 
- [x] Added conda install option to readme.
- [x] Added the following badges to readme.

<!--- BADGES: START --->
[![GitHub - License](https://img.shields.io/github/license/koaning/doubtlab?logo=github&style=flat&color=green)][#github-license]
[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/doubtlab?logo=pypi&style=flat&color=blue)][#pypi-package]
[![PyPI - Package Version](https://img.shields.io/pypi/v/doubtlab?logo=pypi&style=flat&color=orange)][#pypi-package]
[![PyPI - Downloads](https://img.shields.io/pypi/dm/doubtlab?logo=pypi&style=flat&color=green)][#pypi-package]
[![Conda - Platform](https://img.shields.io/conda/pn/conda-forge/doubtlab?logo=anaconda&style=flat)][#conda-forge-package]
[![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/doubtlab?logo=anaconda&style=flat&color=orange)][#conda-forge-package]
[![Docs - GitHub.io](https://img.shields.io/static/v1?logo=github&style=flat&color=pink&label=docs&message=doubtlab)][#docs-package]
<!--- [![Conda](https://img.shields.io/conda/dn/conda-forge/doubtlab?logo=anaconda)][#conda-forge-package] --->

[#github-license]: https://github.com/koaning/doubtlab/blob/main/LICENSE
[#pypi-package]: https://pypi.org/project/doubtlab/
[#conda-forge-package]: https://anaconda.org/conda-forge/doubtlab
[#docs-package]: https://koaning.github.io/doubtlab/
<!--- BADGES: END --->